### PR TITLE
feat: Generalize hard-coded UTF-8 encoding

### DIFF
--- a/etcd_client.pyi
+++ b/etcd_client.pyi
@@ -8,7 +8,7 @@ from typing import Any, AsyncIterator, Final, Optional
 
 @dataclass
 class EtcdLockOption:
-    lock_name: str
+    lock_name: bytes
     timeout: Optional[float]
     ttl: Optional[int]
 
@@ -30,31 +30,31 @@ class CompareOp:
 
 class Compare:
     @staticmethod
-    def version(key: str, cmp: "CompareOp", version: int) -> "Compare": ...
+    def version(key: bytes, cmp: "CompareOp", version: int) -> "Compare": ...
     """
     Compares the version of the given key.
     """
     @staticmethod
-    def create_revision(key: str, cmp: "CompareOp", revision: int) -> "Compare": ...
+    def create_revision(key: bytes, cmp: "CompareOp", revision: int) -> "Compare": ...
     """
     Compares the creation revision of the given key.
     """
     @staticmethod
-    def mod_revision(key: str, cmp: "CompareOp", revision: int) -> "Compare": ...
+    def mod_revision(key: bytes, cmp: "CompareOp", revision: int) -> "Compare": ...
     """
     Compares the last modified revision of the given key.
     """
     @staticmethod
-    def value(key: str, cmp: "CompareOp", value: str) -> "Compare": ...
+    def value(key: bytes, cmp: "CompareOp", value: bytes) -> "Compare": ...
     """
     Compares the value of the given key.
     """
     @staticmethod
-    def lease(key: str, cmp: "CompareOp", lease: int) -> "Compare": ...
+    def lease(key: bytes, cmp: "CompareOp", lease: int) -> "Compare": ...
     """
     Compares the lease id of the given key.
     """
-    def with_range(self, end: list[int]) -> "Compare": ...
+    def with_range(self, end: bytes) -> "Compare": ...
     """
     Sets the comparison to scan the range [key, end).
     """
@@ -95,11 +95,11 @@ class TxnOp:
     """
 
     @staticmethod
-    def get(key: str) -> "TxnOp": ...
+    def get(key: bytes) -> "TxnOp": ...
     @staticmethod
-    def put(key: str, value: str) -> "TxnOp": ...
+    def put(key: bytes, value: bytes) -> "TxnOp": ...
     @staticmethod
-    def delete(key: str) -> "TxnOp": ...
+    def delete(key: bytes) -> "TxnOp": ...
     @staticmethod
     def txn(txn: "Txn") -> "TxnOp": ...
 
@@ -154,21 +154,15 @@ class CondVar:
         """ """
 
 class Communicator:
-    async def get(self, key: str) -> str:
+    async def get(self, key: bytes) -> list[int]:
         """
         Gets the key from the key-value store.
         """
-    async def get_prefix(self, key: str) -> dict[str, Any]:
+    async def get_prefix(self, key: bytes) -> list[tuple[list[int], list[int]]]:
         """
         Gets the key from the key-value store.
         """
-    async def put(self, key: str, value: str) -> None:
-        """
-        Put the given key into the key-value store.
-        A put request increments the revision of the key-value store
-        and generates one event in the event history.
-        """
-    async def put_prefix(self, key: str, value: dict[str, Any]) -> None:
+    async def put(self, key: bytes, value: bytes) -> None:
         """
         Put the given key into the key-value store.
         A put request increments the revision of the key-value store
@@ -181,19 +175,17 @@ class Communicator:
         and generates events with the same revision for every completed operation.
         It is not allowed to modify the same key several times within one txn.
         """
-    async def delete(self, key: str) -> None:
+    async def delete(self, key: bytes) -> None:
         """
         Deletes the given key from the key-value store.
         """
-    async def delete_prefix(self, key: str) -> None:
+    async def delete_prefix(self, key: bytes) -> None:
         """
         Deletes the given key from the key-value store.
         """
-    async def keys_prefix(self, key: str) -> list[str]:
+    async def keys_prefix(self, key: bytes) -> list[list[int]]:
         """ """
-    async def replace(self, key: str, initial_value: str, new_value: str) -> bool:
-        """ """
-    async def lock(self, name: str) -> None:
+    async def lock(self, name: bytes) -> None:
         """
         Lock acquires a distributed shared lock on a given named lock.
         On success, it will return a unique key that exists so long as the
@@ -202,7 +194,7 @@ class Communicator:
         lock ownership. The lock is held until Unlock is called on the key or the
         lease associate with the owner expires.
         """
-    async def unlock(self, key: str) -> None:
+    async def unlock(self, name: bytes) -> None:
         """
         Unlock takes a key returned by Lock and releases the hold on lock. The
         next Lock caller waiting for the lock will then be woken up and given
@@ -225,7 +217,7 @@ class Communicator:
         """
     def watch(
         self,
-        key: str,
+        key: bytes,
         *,
         once: Optional[bool] = False,
         ready_event: Optional["CondVar"] = None,
@@ -238,7 +230,7 @@ class Communicator:
         """
     def watch_prefix(
         self,
-        key: str,
+        key: bytes,
         *,
         once: Optional[bool] = False,
         ready_event: Optional["CondVar"] = None,
@@ -261,16 +253,16 @@ class Watch:
 class WatchEvent:
     """ """
 
-    key: str
-    value: str
+    key: bytes
+    value: bytes
     event: "WatchEventType"
-    prev_value: Optional[str]
+    prev_value: Optional[bytes]
 
     def __init__(
-        key: str,
-        value: str,
+        key: bytes,
+        value: bytes,
         event: "WatchEventType",
-        prev_value: Optional[str] = None,
+        prev_value: Optional[bytes] = None,
     ) -> None: ...
 
 class WatchEventType:
@@ -296,7 +288,7 @@ class CondVar:
 class ClientError(Exception):
     """ """
 
-class GRpcStatusError(ClientError):
+class GRPCStatusError(ClientError):
     """ """
 
 class InvalidArgsError(ClientError):
@@ -332,7 +324,7 @@ class EndpointError(ClientError):
 class LockError(ClientError):
     """ """
 
-class GRpcStatusCode(Enum):
+class GRPCStatusCode(Enum):
     Ok = 0
     """The operation completed successfully."""
 

--- a/src/communicator.rs
+++ b/src/communicator.rs
@@ -1,4 +1,4 @@
-use etcd_client::{Client as EtcdClient, PutOptions};
+use etcd_client::Client as EtcdClient;
 use etcd_client::{DeleteOptions, GetOptions, WatchOptions};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -18,8 +18,9 @@ pub struct PyCommunicator(pub Arc<Mutex<EtcdClient>>);
 #[pymethods]
 impl PyCommunicator {
     // TODO: Implement and use the CRUD response types
-    fn get<'a>(&'a self, py: Python<'a>, key: String) -> PyResult<&'a PyAny> {
+    fn get<'a>(&'a self, py: Python<'a>, key: &PyBytes) -> PyResult<&'a PyAny> {
         let client = self.0.clone();
+        let key = key.as_bytes().to_vec();
         future_into_py(py, async move {
             let mut client = client.lock().await;
             let result = client.get(key, None).await;

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1,6 +1,7 @@
 use etcd_client::{Compare, CompareOp};
 use pyo3::prelude::*;
 use pyo3::pyclass::CompareOp as PyO3CompareOp;
+use pyo3::types::PyBytes;
 
 #[derive(Clone)]
 #[pyclass(name = "CompareOp")]
@@ -42,31 +43,38 @@ pub struct PyCompare(pub Compare);
 #[pymethods]
 impl PyCompare {
     #[staticmethod]
-    fn version(key: String, cmp: PyCompareOp, version: i64) -> PyResult<Self> {
+    fn version(key: &PyBytes, cmp: PyCompareOp, version: i64) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         Ok(PyCompare(Compare::version(key, cmp.0, version)))
     }
 
     #[staticmethod]
-    fn create_revision(key: String, cmp: PyCompareOp, revision: i64) -> PyResult<Self> {
+    fn create_revision(key: &PyBytes, cmp: PyCompareOp, revision: i64) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         Ok(PyCompare(Compare::create_revision(key, cmp.0, revision)))
     }
 
     #[staticmethod]
-    fn mod_revision(key: String, cmp: PyCompareOp, revision: i64) -> PyResult<Self> {
+    fn mod_revision(key: &PyBytes, cmp: PyCompareOp, revision: i64) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         Ok(PyCompare(Compare::mod_revision(key, cmp.0, revision)))
     }
 
     #[staticmethod]
-    fn value(key: String, cmp: PyCompareOp, value: String) -> PyResult<Self> {
+    fn value(key: &PyBytes, cmp: PyCompareOp, value: &PyBytes) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
+        let value = value.as_bytes().to_vec();
         Ok(PyCompare(Compare::value(key, cmp.0, value)))
     }
 
     #[staticmethod]
-    fn lease(key: String, cmp: PyCompareOp, lease: i64) -> PyResult<Self> {
+    fn lease(key: &PyBytes, cmp: PyCompareOp, lease: i64) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         Ok(PyCompare(Compare::lease(key, cmp.0, lease)))
     }
 
-    fn with_range(&self, end: String) -> PyResult<Self> {
+    fn with_range(&self, end: &PyBytes) -> PyResult<Self> {
+        let end = end.as_bytes().to_vec();
         Ok(PyCompare(self.0.clone().with_range(end)))
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use pyo3::{create_exception, exceptions::PyException, types::PyDict, PyErr, Pyth
 use std::fmt::Debug;
 
 create_exception!(etcd_client, ClientError, PyException);
-create_exception!(etcd_client, GRpcStatusError, ClientError);
+create_exception!(etcd_client, GRPCStatusError, ClientError);
 create_exception!(etcd_client, InvalidArgsError, ClientError);
 create_exception!(etcd_client, InvalidUriError, ClientError);
 create_exception!(etcd_client, IoError, ClientError);
@@ -15,8 +15,8 @@ create_exception!(etcd_client, InvalidHeaderValueError, ClientError);
 create_exception!(etcd_client, EndpointError, ClientError);
 create_exception!(etcd_client, LockError, ClientError);
 
-#[pyclass(name = "GRpcStatusCode")]
-pub enum PyGRpcStatusCode {
+#[pyclass(name = "GRPCStatusCode")]
+pub enum PyGRPCStatusCode {
     Ok = 0,
     Cancelled = 1,
     Unknown = 2,
@@ -54,7 +54,7 @@ impl From<PyClientError> for PyErr {
                     .unwrap();
 
                 let kv_args: PyObject = error_details.into_py(py);
-                GRpcStatusError::new_err(kv_args)
+                GRPCStatusError::new_err(kv_args)
             }),
             etcd_client::Error::InvalidArgs(e) => {
                 InvalidArgsError::new_err(format!("InvalidArgsError(err={})", e))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ use communicator::PyCommunicator;
 use compare::{PyCompare, PyCompareOp};
 use condvar::PyCondVar;
 use error::{
-    ClientError, ElectError, EndpointError, GRpcStatusError, InvalidArgsError,
-    InvalidHeaderValueError, InvalidUriError, IoError, LeaseKeepAliveError, PyGRpcStatusCode,
+    ClientError, ElectError, EndpointError, GRPCStatusError, InvalidArgsError,
+    InvalidHeaderValueError, InvalidUriError, IoError, LeaseKeepAliveError, PyGRPCStatusCode,
     TransportError, Utf8Error, WatchError,
 };
 use lock_manager::PyEtcdLockOption;
@@ -45,10 +45,10 @@ fn etcd_client(py: Python, module: &PyModule) -> PyResult<()> {
     module.add_class::<PyTxnResponse>()?;
     module.add_class::<PyEtcdLockOption>()?;
 
-    module.add_class::<PyGRpcStatusCode>()?;
+    module.add_class::<PyGRPCStatusCode>()?;
 
     module.add("ClientError", py.get_type::<ClientError>())?;
-    module.add("GRpcStatusError", py.get_type::<GRpcStatusError>())?;
+    module.add("GRPCStatusError", py.get_type::<GRPCStatusError>())?;
     module.add("InvalidArgsError", py.get_type::<InvalidArgsError>())?;
     module.add("IoError", py.get_type::<IoError>())?;
     module.add("InvalidUriError", py.get_type::<InvalidUriError>())?;

--- a/src/lock_manager.rs
+++ b/src/lock_manager.rs
@@ -49,8 +49,6 @@ pub struct EtcdLockManager {
 
 impl EtcdLockManager {
     pub fn new(client: PyClient, lock_opt: PyEtcdLockOption) -> Self {
-        let lock_name = lock_opt.lock_name.clone();
-
         Self {
             client,
             lock_name: lock_opt.lock_name,

--- a/src/txn.rs
+++ b/src/txn.rs
@@ -1,5 +1,5 @@
 use etcd_client::{DeleteOptions, GetOptions, PutOptions, Txn, TxnOp};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyBytes};
 
 use crate::compare::PyCompare;
 
@@ -10,18 +10,23 @@ pub struct PyTxnOp(pub TxnOp);
 #[pymethods]
 impl PyTxnOp {
     #[staticmethod]
-    fn get(key: String) -> PyResult<Self> {
+    fn get(key: &PyBytes) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         let options = GetOptions::new();
         Ok(PyTxnOp(TxnOp::get(key, Some(options))))
     }
+
     #[staticmethod]
-    fn put(key: String, value: String) -> PyResult<Self> {
+    fn put(key: &PyBytes, value: &PyBytes) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
+        let value = value.as_bytes().to_vec();
         let options = PutOptions::new();
         Ok(PyTxnOp(TxnOp::put(key, value, Some(options))))
     }
 
     #[staticmethod]
-    fn delete(key: String) -> PyResult<Self> {
+    fn delete(key: &PyBytes) -> PyResult<Self> {
+        let key = key.as_bytes().to_vec();
         let options = DeleteOptions::new();
         Ok(PyTxnOp(TxnOp::delete(key, Some(options))))
     }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -16,7 +16,7 @@ use crate::watch_event_stream::PyWatchEventStream;
 #[derive(Clone)]
 pub struct PyWatch {
     client: Arc<Mutex<EtcdClient>>,
-    key: String,
+    key: Vec<u8>,
     once: bool,
     options: Option<WatchOptions>,
     watcher: Arc<Mutex<Option<Watcher>>>,
@@ -30,7 +30,7 @@ pub struct PyWatch {
 impl PyWatch {
     pub fn new(
         client: Arc<Mutex<EtcdClient>>,
-        key: String,
+        key: Vec<u8>,
         once: bool,
         options: Option<WatchOptions>,
         ready_event: Option<PyCondVar>,

--- a/src/watch_event.rs
+++ b/src/watch_event.rs
@@ -7,10 +7,10 @@ use pyo3::pyclass::CompareOp;
 #[pyclass(get_all, name = "WatchEvent")]
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct PyWatchEvent {
-    key: String,
-    value: String,
+    key: Vec<u8>,
+    value: Vec<u8>,
     event: PyWatchEventType,
-    prev_value: Option<String>,
+    prev_value: Option<Vec<u8>>,
 }
 
 #[pymethods]
@@ -18,10 +18,10 @@ impl PyWatchEvent {
     #[new]
     #[pyo3(signature = (key, value, event, prev_value))]
     fn new(
-        key: String,
-        value: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
         event: PyWatchEventType,
-        prev_value: Option<String>,
+        prev_value: Option<Vec<u8>>,
     ) -> Self {
         Self {
             key,
@@ -33,7 +33,7 @@ impl PyWatchEvent {
 
     pub fn __repr__(&self) -> String {
         format!(
-            "Event(event={:?}, key={}, value={}, prev_value={:?})",
+            "Event(event={:?}, key={:?}, value={:?}, prev_value={:?})",
             self.event, self.key, self.value, self.prev_value
         )
     }
@@ -50,8 +50,8 @@ impl PyWatchEvent {
 impl From<EtcdClientEvent> for PyWatchEvent {
     fn from(event: EtcdClientEvent) -> Self {
         let kv = event.kv().unwrap();
-        let key = String::from_utf8(kv.key().to_owned()).unwrap();
-        let value = String::from_utf8(kv.value().to_owned()).unwrap();
+        let key = kv.key().to_owned();
+        let value = kv.value().to_owned();
         let prev_value = None;
         let event = PyWatchEventType(event.event_type());
         Self {

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,4 +1,10 @@
 """
+Backend.AI AsyncEtcd Client Copy
+Ref: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/common/etcd.py
+=================================================================================
+"""
+
+"""
 An asynchronous client wrapper for etcd v3 API.
 
 It uses the etcd3 library using a thread pool executor.
@@ -44,8 +50,8 @@ from etcd_client import (
     CompareOp,
     CondVar,
     ConnectOptions,
-    GRpcStatusCode,
-    GRpcStatusError,
+    GRPCStatusCode,
+    GRPCStatusError,
     WatchEvent,
 )
 
@@ -340,6 +346,7 @@ class AsyncEtcd:
                     self._mangle_key(f"{_slash(scope_prefix)}{key}")
                 )
                 if value is not None:
+                    value = bytes(value).decode(self.encoding)
                     return value
         return None
 
@@ -411,7 +418,8 @@ class AsyncEtcd:
                 )
                 values = await communicator.get_prefix(mangled_key_prefix)
                 pair_sets.append(
-                    [(self._demangle_key(k), v) for k, v in values.items()]
+                    # [(self._demangle_key(bytes(k)), bytes(v).decode(self.encoding)) for k, v in values]
+                    [(self._demangle_key(bytes(k).decode(self.encoding)), bytes(v).decode(self.encoding)) for k, v in values]
                 )
 
         configs = [
@@ -545,10 +553,10 @@ class AsyncEtcd:
                 ):
                     yield ev
                 ended_without_error = True
-            except GRpcStatusError as e:
+            except GRPCStatusError as e:
                 err_detail = e.args[0]
 
-                if err_detail["code"] == GRpcStatusCode.Unavailable:
+                if err_detail["code"] == GRPCStatusCode.Unavailable:
                     log.warn(
                         "watch(): error while connecting to Etcd server, retrying..."
                     )
@@ -587,10 +595,10 @@ class AsyncEtcd:
                 ):
                     yield ev
                 ended_without_error = True
-            except GRpcStatusError as e:
+            except GRPCStatusError as e:
                 err_detail = e.args[0]
 
-                if err_detail["code"] == GRpcStatusCode.Unavailable:
+                if err_detail["code"] == GRPCStatusCode.Unavailable:
                     log.warn(
                         "watch_prefix(): error while connecting to Etcd server, retrying..."
                     )


### PR DESCRIPTION
In the existing code, if the assumption that all strings are encoded in UTF-8 is broken, it will lead to a panic.
This is an unnecessary assumption in `etcd-client-py`, and handling it as `Vec<u8>` is the correct approach.
This PR makes the following changes:

- Remove UTF-8 encoding assumption
- Reflect test harness changes from Backend.AI
- Remove useless APIs (`put_prefix`, `replace`)
- Fix some typos (`GRpcStatusCode` -> `GRPCStatusCode`)