### PR TITLE
feature: Add Python 3.14/3.14t builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           {os: "ubuntu-22.04", arch: "x86_64", etcd_arch: "amd64"},
           {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"},
         ]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout the revision
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Set up Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -59,7 +60,43 @@ jobs:
           {os: "ubuntu-22.04-arm", arch: "aarch64", maturin_arch: "aarch_64"},
         ]
         manylinux: ["manylinux2014"]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v4
+      - name: Build the wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          PROTOC: /home/runner/.local/bin/protoc
+        with:
+          command: build
+          args: --release -o dist -i python${{ matrix.python-version }}
+          before-script-linux: |
+            PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+            curl -LO $PB_REL/download/v23.2/protoc-23.2-linux-${{ matrix.platform.maturin_arch }}.zip
+            unzip protoc-23.2-linux-${{ matrix.platform.maturin_arch }}.zip -d $HOME/.local
+            export PATH="$PATH:$HOME/.local/bin"
+          manylinux: ${{ matrix.manylinux }}
+          target: ${{ matrix.platform.arch }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.manylinux }}-${{ matrix.platform.arch }}-${{ matrix.python-version }}
+          path: dist
+
+  release-linux-freethreaded:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          {os: "ubuntu-22.04", arch: "x86_64", maturin_arch: "x86_64"},
+          {os: "ubuntu-22.04-arm", arch: "aarch64", maturin_arch: "aarch_64"},
+        ]
+        manylinux: ["manylinux2014"]
+        python-version: ["3.14t"]
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout the revision
@@ -91,7 +128,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v4
+      - name: Install prerequisites
+        run: |
+          brew install protobuf
+      - name: Build the wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release -o dist --target universal2-apple-darwin -i python${{ matrix.python-version }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-universal2-${{ matrix.python-version }}
+          path: dist/*
+
+  release-macos-freethreaded:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: test
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14t"]
     steps:
       - name: Checkout the revision
         uses: actions/checkout@v4
@@ -132,7 +194,7 @@ jobs:
           path: dist
 
   publish-to-pypi:
-    needs: [release-linux, release-macos, release-source]
+    needs: [release-linux, release-linux-freethreaded, release-macos, release-macos-freethreaded, release-source]
     environment: deploy-to-pypi
     permissions:
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "inventory",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
+checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
 dependencies = [
  "futures",
  "once_cell",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca31e43a0f205f2960208938135e37e579e61e10b36b4e7f49b0e8f60fab5b83"
+checksum = "bcd7d70ee0ca1661c40407e6f84e4463ef2658c90a9e2fbbd4515b2bcdfcaeca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -754,19 +754,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -774,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -786,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 etcd-client = "0.16.1"
-pyo3 = { version = "0.25.1", features = ["extension-module", "multiple-pymethods"] }
-pyo3-async-runtimes = { version = "0.25.0", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.27.2", features = ["extension-module", "multiple-pymethods"] }
+pyo3-async-runtimes = { version = "0.27.0", features = ["attributes", "tokio-runtime"] }
 scopeguard = "1.2.0"
 tokio = { version = "1.46.1", features = ["sync"] }
 tokio-stream = "0.1.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,12 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python"
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]
@@ -22,5 +27,5 @@ homepage = "https://github.com/lablup/etcd-client-py"
 repository = "https://github.com/lablup/etcd-client-py"
 
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.7,<2.0"]
 build-backend = "maturin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-maturin==1.9.1
+maturin==1.10.2
 pytest~=8.4.1
 pytest-asyncio~=1.1.0
 trafaret~=2.1

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -27,7 +27,7 @@ impl PyCompareOp {
         }
     }
 
-    pub fn __richcmp__(&self, py: Python, rhs: &PyCompareOp, op: PyO3CompareOp) -> PyResult<PyObject> {
+    pub fn __richcmp__(&self, py: Python, rhs: &PyCompareOp, op: PyO3CompareOp) -> PyResult<Py<PyAny>> {
         match op {
             PyO3CompareOp::Eq => (self.0 == rhs.0)
                 .into_pyobject(py)

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ pub struct PyClientError(pub etcd_client::Error);
 impl From<PyClientError> for PyErr {
     fn from(error: PyClientError) -> Self {
         match &error.0 {
-            etcd_client::Error::GRpcStatus(e) => Python::with_gil(|py| {
+            etcd_client::Error::GRpcStatus(e) => Python::attach(|py| {
                 let error_details = PyDict::new(py);
                 error_details.set_item("code", e.code() as u64).unwrap();
                 error_details
@@ -55,7 +55,7 @@ impl From<PyClientError> for PyErr {
                     .set_item("message", e.message().to_owned())
                     .unwrap();
 
-                let kv_args: PyObject = error_details.into();
+                let kv_args: Py<PyAny> = error_details.unbind().into_any();
                 GRPCStatusError::new_err(kv_args)
             }),
             etcd_client::Error::InvalidArgs(e) => {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -83,7 +83,7 @@ impl PyWatch {
         self.clone()
     }
 
-    fn __anext__<'a>(&'a mut self, py: Python<'a>) -> PyResult<Option<PyObject>> {
+    fn __anext__<'a>(&'a mut self, py: Python<'a>) -> PyResult<Option<Py<PyAny>>> {
         let watch = Arc::new(Mutex::new(self.clone()));
         let event_stream_init_notifier = self.event_stream_init_notifier.clone();
         let watcher = self.watcher.clone();

--- a/src/watch_event.rs
+++ b/src/watch_event.rs
@@ -39,7 +39,7 @@ impl PyWatchEvent {
         )
     }
 
-    fn __richcmp__(&self, py: Python, other: &Self, op: CompareOp) -> PyResult<PyObject> {
+    fn __richcmp__(&self, py: Python, other: &Self, op: CompareOp) -> PyResult<Py<PyAny>> {
         match op {
             CompareOp::Eq => (self == other)
                 .into_pyobject(py)
@@ -91,7 +91,7 @@ impl PyWatchEventType {
         }
     }
 
-    pub fn __richcmp__(&self, py: Python, rhs: &PyWatchEventType, op: CompareOp) -> PyResult<PyObject> {
+    pub fn __richcmp__(&self, py: Python, rhs: &PyWatchEventType, op: CompareOp) -> PyResult<Py<PyAny>> {
         match op {
             CompareOp::Eq => (self.0 == rhs.0)
                 .into_pyobject(py)


### PR DESCRIPTION
## Summary

Add support for Python 3.14 and free-threaded Python 3.14t builds.

## Changes

### Cargo Dependencies
- Update `pyo3`: 0.25.1 → 0.27.2
- Update `pyo3-async-runtimes`: 0.25.0 → 0.27.0

### Build Configuration
- Update `maturin`: 1.9.1 → 1.10.2 (includes fixes for free-threaded Python 3.14 builds)
- Update minimum maturin requirement: `>=1.0,<2.0` → `>=1.7,<2.0`

### CI Workflow (`.github/workflows/ci.yml`)
- Add Python 3.14 and 3.14t (free-threaded) to test matrix
- Add `allow-prereleases: true` to setup-python action
- Add `release-linux-freethreaded` job for free-threaded Linux wheels
- Add `release-macos-freethreaded` job for free-threaded macOS wheels
- Update `publish-to-pypi` to include free-threaded wheel jobs

### Code Fixes (deprecation warnings)
- Replace deprecated `PyObject` with `Py<PyAny>` in:
  - `src/compare.rs`
  - `src/watch.rs`
  - `src/watch_event.rs`
- Replace deprecated `Python::with_gil` with `Python::attach` in:
  - `src/error.rs`

### Package Metadata (`pyproject.toml`)
- Add Python version classifiers (3.10-3.14)

## Wheel Builds

| Python Version | Wheel ABI Tag | Platforms |
|---------------|---------------|-----------|
| 3.11, 3.12, 3.13, 3.14 | `cp3XX-cp3XX` | Linux (x86_64, aarch64), macOS (universal2) |
| 3.14t (free-threaded) | `cp314-cp314t` | Linux (x86_64, aarch64), macOS (universal2) |

## Test Plan
- [x] `cargo check` passes without warnings
- [x] CI tests pass for Python 3.11, 3.12, 3.13, 3.14, 3.14t
- [x] Wheel builds succeed for all platforms

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)