### PR TITLE
feat: Automate tokio runtime cleanup via reference counting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           {os: "ubuntu-22.04", arch: "x86_64", etcd_arch: "amd64"},
           {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"},
         ]
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        # Use 3.14+gil to explicitly request GIL-enabled Python (not free-threaded)
+        # This prevents uv from accidentally selecting 3.14t when 3.14 is requested
+        python-version: ["3.11", "3.12", "3.13", "3.14+gil", "3.14t"]
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout the revision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Check python build
       run: |
         uv run --no-project python -c 'import sys; print(sys.prefix); print(sys.version_info)'
-        uv run --no-project python -c 'import sysconfig; print(f"Py_GIL_DISABLED={sysconfig.get_config_var("Py_GIL_DISABLED")}")'
+        uv run --no-project python -c 'import sysconfig; flag=sysconfig.get_config_var("Py_GIL_DISABLED"); print(f"Py_GIL_DISABLED={flag}")'
         uv run --no-project python -c 'import sys; print(f"{sys.abiflags=}")'
     - name: Install dependencies and build the package
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
         uv sync --locked --all-extras --no-install-project
         PYO3_PRINT_CONFIG=1 uv run maturin develop 2>&1 || true
         uv run maturin develop
+    - name: Upload built extension module (for debugging)
+      if: matrix.platform.arch == 'aarch64' && matrix.python-version == '3.14'
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-extension-${{ matrix.platform.arch }}-${{ matrix.python-version }}
+        path: python/etcd_client/*.so
     - name: Test
       run: |
         uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,23 +49,12 @@ jobs:
     - name: Check python build
       run: |
         uv run --no-project python -c 'import sys; print(sys.prefix); print(sys.version_info)'
-        uv run --no-project python -c 'import sysconfig; print("Py_GIL_DISABLED=", sysconfig.get_config_var("Py_GIL_DISABLED"))'
+        uv run --no-project python -c 'import sysconfig; print(f"Py_GIL_DISABLED={sysconfig.get_config_var("Py_GIL_DISABLED")}")'
         uv run --no-project python -c 'import sys; print(f"{sys.abiflags=}")'
-        which python
-        python --version
-        which -a python3.14 || true
-        which -a python3.14t || true
     - name: Install dependencies and build the package
       run: |
         uv sync --locked --all-extras --no-install-project
-        PYO3_PRINT_CONFIG=1 uv run maturin develop 2>&1 || true
         uv run maturin develop
-    - name: Upload built extension module (for debugging)
-      if: matrix.platform.arch == 'aarch64' && matrix.python-version == '3.14'
-      uses: actions/upload-artifact@v4
-      with:
-        name: debug-extension-${{ matrix.platform.arch }}-${{ matrix.python-version }}
-        path: python/etcd_client/*.so
     - name: Test
       run: |
         uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 0  # Required to fetch submodule commits on non-default branches
     - name: Set up Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,7 @@ jobs:
           {os: "ubuntu-22.04", arch: "x86_64", etcd_arch: "amd64"},
           {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"},
         ]
-        # Note: 3.14 = GIL-enabled (default), 3.14t = free-threaded
-        # uv installs GIL-enabled Python by default when using "3.14"
         python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
-        exclude:
-          # ARM64 + Python 3.14 (GIL-enabled) has a bug where uv's Python build
-          # incorrectly triggers PyO3 to generate free-threaded code, causing
-          # "undefined symbol: PyUnstable_Module_SetGIL" errors at runtime.
-          # ARM64 + Python 3.14t (free-threaded) works correctly.
-          # See: https://github.com/astral-sh/uv/issues/16253
-          - platform: {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"}
-            python-version: "3.14"
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout the revision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       with:
         toolchain: stable
         override: true
+        # Include Python version in cache key to prevent cross-contamination
+        # between GIL-enabled (3.14) and free-threaded (3.14t) builds
+        cache-key: py${{ matrix.python-version }}
     - name: Install protobuf compiler
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,19 @@ jobs:
       with:
         enable-cache: true
         python-version: ${{ matrix.python-version }}
+    - name: Check python build
+      run: |
+        uv run --no-project python -c 'import sys; print(sys.prefix); print(sys.version_info)'
+        uv run --no-project python -c 'import sysconfig; print("Py_GIL_DISABLED=", sysconfig.get_config_var("Py_GIL_DISABLED"))'
+        uv run --no-project python -c 'import sys; print(f"{sys.abiflags=}")'
+        which python
+        python --version
+        which -a python3.14 || true
+        which -a python3.14t || true
     - name: Install dependencies and build the package
       run: |
         uv sync --locked --all-extras --no-install-project
+        PYO3_PRINT_CONFIG=1 uv run maturin develop 2>&1 || true
         uv run maturin develop
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           {os: "ubuntu-22.04", arch: "x86_64", etcd_arch: "amd64"},
           {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"},
         ]
-        # Use 3.14+gil to explicitly request GIL-enabled Python (not free-threaded)
-        # This prevents uv from accidentally selecting 3.14t when 3.14 is requested
-        python-version: ["3.11", "3.12", "3.13", "3.14+gil", "3.14t"]
+        # Note: 3.14 = GIL-enabled (default), 3.14t = free-threaded
+        # uv installs GIL-enabled Python by default when using "3.14"
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout the revision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
         # Note: 3.14 = GIL-enabled (default), 3.14t = free-threaded
         # uv installs GIL-enabled Python by default when using "3.14"
         python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        exclude:
+          # ARM64 + Python 3.14 (GIL-enabled) has a bug where uv's Python build
+          # incorrectly triggers PyO3 to generate free-threaded code, causing
+          # "undefined symbol: PyUnstable_Module_SetGIL" errors at runtime.
+          # ARM64 + Python 3.14t (free-threaded) works correctly.
+          # See: https://github.com/astral-sh/uv/issues/16253
+          - platform: {os: "ubuntu-22.04-arm", arch: "aarch64", etcd_arch: "arm64"}
+            python-version: "3.14"
     runs-on: ${{ matrix.platform.os }}
     steps:
     - name: Checkout the revision

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/pyo3-async-runtimes"]
 	path = vendor/pyo3-async-runtimes
 	url = https://github.com/lablup/pyo3-async-runtimes.git
+	branch = add-explicit-shutdown-api

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,21 +209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,23 +223,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -285,13 +253,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -763,7 +728,8 @@ dependencies = [
 name = "pyo3-async-runtimes"
 version = "0.27.0"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "parking_lot",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +592,29 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -733,6 +765,7 @@ version = "0.27.0"
 dependencies = [
  "futures",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "pyo3",
  "pyo3-async-runtimes-macros",
@@ -806,6 +839,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -1154,6 +1196,12 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ async def main():
         print(bytes(value).decode())  # testvalue
 ```
 
-### Cleanup on shutdown
+### Automatic runtime cleanup
 
-To prevent segfaults or GIL state violations during Python interpreter shutdown, you should call `cleanup_runtime()` at the end of your main async function before the event loop shuts down:
+The tokio runtime is automatically cleaned up when the last client context exits. In most cases, no explicit cleanup is needed:
 
 ```python
-from etcd_client import EtcdClient, cleanup_runtime
+from etcd_client import EtcdClient
 
 async def main():
     etcd = EtcdClient(['http://127.0.0.1:2379'])
@@ -41,13 +41,21 @@ async def main():
         await communicator.put('testkey'.encode(), 'testvalue'.encode())
         value = await communicator.get('testkey'.encode())
         print(bytes(value).decode())
-    # Cleanup the tokio runtime before returning
-    cleanup_runtime()
+    # Runtime automatically cleaned up when context exits
 
 asyncio.run(main())
 ```
 
-This function signals the internal tokio runtime to shut down gracefully, waiting up to 5 seconds for pending tasks to complete.
+The library uses reference counting to track active client contexts. When the last context exits, the tokio runtime is gracefully shut down, waiting up to 5 seconds for pending tasks to complete. If you create new clients after this, the runtime is automatically re-initialized.
+
+For advanced use cases requiring explicit control, `cleanup_runtime()` is still available:
+
+```python
+from etcd_client import cleanup_runtime
+
+# Force cleanup at a specific point (usually not needed)
+cleanup_runtime()
+```
 
 `EtcdCommunicator.get_prefix(prefix)` will return a tuple of list containing all key-values with given key prefix.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "maturin>=1.10.2",
-  "pytest>=8.4.1,<9",
-  "pytest-asyncio>=1.1.0,<2",
+  "maturin>=1.11.2",
+  "pytest>=9.0.2,<10",
+  "pytest-asyncio>=1.3.0,<2",
   "trafaret>=2.1,<3",
-  "testcontainers>=4.12.0,<5",
+  "testcontainers>=4.13.3,<5",
 ]
 
 [project.urls]
@@ -35,12 +35,12 @@ repository = "https://github.com/lablup/etcd-client-py"
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.8.5",
-    "mypy>=1.13.0",
+    "ruff>=0.14.10",
+    "mypy>=1.19.1",
 ]
 
 [build-system]
-requires = ["maturin>=1.7,<2.0"]
+requires = ["maturin>=1.11,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/python/etcd_client/__init__.py
+++ b/python/etcd_client/__init__.py
@@ -1,5 +1,5 @@
 from .etcd_client import *  # noqa: F403
-from .etcd_client import cleanup_runtime  # noqa: F401
+from .etcd_client import active_context_count, cleanup_runtime  # noqa: F401
 
 __doc__ = etcd_client.__doc__  # noqa: F405
 if hasattr(etcd_client, "__all__"):  # noqa: F405

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use etcd_client::{Client as EtcdClient, ConnectOptions};
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
+use pyo3::types::{PyDict, PyTuple};
 use pyo3_async_runtimes::tokio::future_into_py;
 use std::sync::Arc;
 use std::time::Duration;
@@ -168,16 +168,50 @@ impl PyClient {
             None
         };
 
-        future_into_py(py, async move {
+        // Create the tokio async cleanup coroutine
+        // Returns True if this was the last client and shutdown was triggered
+        let inner_cleanup = future_into_py(py, async move {
             if let Some(lock_manager) = lock_manager {
                 lock_manager.lock().await.handle_aexit().await?;
             }
 
             // Decrement context count after all cleanup is done
             // This may trigger runtime shutdown if this was the last active context
-            crate::runtime::exit_context();
+            let triggered_shutdown = crate::runtime::exit_context();
 
-            Ok(())
-        })
+            Ok(triggered_shutdown)
+        })?;
+
+        // Get the join function for use in the wrapper
+        let etcd_client = py.import("etcd_client")?;
+        let join_fn = etcd_client.getattr("_join_pending_shutdown")?;
+
+        // Create a Python wrapper coroutine that:
+        // 1. Awaits the inner cleanup
+        // 2. If shutdown was triggered, awaits the blocking join via to_thread
+        let asyncio = py.import("asyncio")?;
+        let to_thread = asyncio.getattr("to_thread")?;
+
+        // Build the wrapper coroutine using Python code
+        let globals = PyDict::new(py);
+        globals.set_item("inner_cleanup", inner_cleanup)?;
+        globals.set_item("join_fn", join_fn)?;
+        globals.set_item("to_thread", to_thread)?;
+
+        py.run(
+            c"
+async def _aexit_wrapper():
+    triggered_shutdown = await inner_cleanup
+    if triggered_shutdown:
+        await to_thread(join_fn)
+    return None
+_result = _aexit_wrapper()
+",
+            Some(&globals),
+            None,
+        )?;
+
+        let result = globals.get_item("_result")?.unwrap();
+        Ok(result)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod etcd_client {
         // Add runtime functions
         m.add_function(wrap_pyfunction!(crate::runtime::cleanup_runtime, m)?)?;
         m.add_function(wrap_pyfunction!(crate::runtime::active_context_count, m)?)?;
+        m.add_function(wrap_pyfunction!(crate::runtime::_trigger_shutdown, m)?)?;
         m.add_function(wrap_pyfunction!(crate::runtime::_join_pending_shutdown, m)?)?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,7 @@ mod etcd_client {
     };
     use pyo3::prelude::*;
 
-    #[pymodule_export]
-    use crate::txn::{PyTxn, PyTxnOp};
-
-    #[pymodule_export]
-    use crate::txn_response::PyTxnResponse;
-
-    #[pymodule_export]
-    use crate::lock_manager::PyEtcdLockOption;
-
+    // Classes
     #[pymodule_export]
     use crate::client::{PyClient, PyConnectOptions};
 
@@ -43,6 +35,15 @@ mod etcd_client {
 
     #[pymodule_export]
     use crate::condvar::PyCondVar;
+
+    #[pymodule_export]
+    use crate::lock_manager::PyEtcdLockOption;
+
+    #[pymodule_export]
+    use crate::txn::{PyTxn, PyTxnOp};
+
+    #[pymodule_export]
+    use crate::txn_response::PyTxnResponse;
 
     #[pymodule_export]
     use crate::watch::PyWatch;
@@ -57,6 +58,7 @@ mod etcd_client {
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let py = m.py();
 
+        // Exception types
         m.add("ClientError", py.get_type::<ClientError>())?;
         m.add("GRPCStatusError", py.get_type::<GRPCStatusError>())?;
         m.add("InvalidArgsError", py.get_type::<InvalidArgsError>())?;
@@ -67,15 +69,14 @@ mod etcd_client {
         m.add("Utf8Error", py.get_type::<Utf8Error>())?;
         m.add("LeaseKeepAliveError", py.get_type::<LeaseKeepAliveError>())?;
         m.add("ElectError", py.get_type::<ElectError>())?;
-        m.add(
-            "InvalidHeaderValueError",
-            py.get_type::<InvalidHeaderValueError>(),
-        )?;
+        m.add("InvalidHeaderValueError", py.get_type::<InvalidHeaderValueError>())?;
         m.add("EndpointError", py.get_type::<EndpointError>())?;
 
-        // Add runtime functions
+        // Runtime management (public API)
         m.add_function(wrap_pyfunction!(crate::runtime::cleanup_runtime, m)?)?;
         m.add_function(wrap_pyfunction!(crate::runtime::active_context_count, m)?)?;
+
+        // Runtime internals (used by __aexit__)
         m.add_function(wrap_pyfunction!(crate::runtime::_trigger_shutdown, m)?)?;
         m.add_function(wrap_pyfunction!(crate::runtime::_join_pending_shutdown, m)?)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,6 @@ mod etcd_client {
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let py = m.py();
 
-        // Register atexit handler for tokio runtime cleanup.
-        // This ensures runtime threads are properly joined before Python finalizes,
-        // preventing SIGSEGV when tokio threads run during interpreter shutdown.
-        pyo3_async_runtimes::tokio::register_atexit_cleanup(py)?;
-
         m.add("ClientError", py.get_type::<ClientError>())?;
         m.add("GRPCStatusError", py.get_type::<GRPCStatusError>())?;
         m.add("InvalidArgsError", py.get_type::<InvalidArgsError>())?;
@@ -81,6 +76,7 @@ mod etcd_client {
         // Add runtime functions
         m.add_function(wrap_pyfunction!(crate::runtime::cleanup_runtime, m)?)?;
         m.add_function(wrap_pyfunction!(crate::runtime::active_context_count, m)?)?;
+        m.add_function(wrap_pyfunction!(crate::runtime::_join_pending_shutdown, m)?)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,9 @@ mod etcd_client {
         )?;
         m.add("EndpointError", py.get_type::<EndpointError>())?;
 
-        // Add runtime cleanup function
+        // Add runtime functions
         m.add_function(wrap_pyfunction!(crate::runtime::cleanup_runtime, m)?)?;
+        m.add_function(wrap_pyfunction!(crate::runtime::active_context_count, m)?)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,12 @@ mod etcd_client {
     #[pymodule_init]
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let py = m.py();
+
+        // Register atexit handler for tokio runtime cleanup.
+        // This ensures runtime threads are properly joined before Python finalizes,
+        // preventing SIGSEGV when tokio threads run during interpreter shutdown.
+        pyo3_async_runtimes::tokio::register_atexit_cleanup(py)?;
+
         m.add("ClientError", py.get_type::<ClientError>())?;
         m.add("GRPCStatusError", py.get_type::<GRPCStatusError>())?;
         m.add("InvalidArgsError", py.get_type::<InvalidArgsError>())?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,92 +1,58 @@
 use pyo3::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Count of active client context managers (those currently inside `async with`).
+/// Shutdown timeout in milliseconds for graceful runtime cleanup.
+const SHUTDOWN_TIMEOUT_MS: u64 = 5000;
+
+/// Active client context count.
 static ACTIVE_CONTEXTS: AtomicUsize = AtomicUsize::new(0);
 
-/// Called when a client enters its async context (`__aenter__`).
-///
-/// Increments the active context count. If this is the first context after
-/// a previous shutdown, the tokio runtime will be lazily re-initialized
-/// on the first spawn operation.
-pub fn enter_context() {
+// ============================================================================
+// Context Counting (internal)
+// ============================================================================
+
+/// Increment context count on `__aenter__`.
+pub(crate) fn enter_context() {
     ACTIVE_CONTEXTS.fetch_add(1, Ordering::SeqCst);
 }
 
-/// Called when a client exits its async context (`__aexit__`).
-///
-/// Decrements the active context count and returns `true` if this was the
-/// last active context (count drops from 1 to 0).
-///
-/// Note: This function does NOT trigger the shutdown directly. The caller
-/// should trigger shutdown from Python AFTER the tokio task completes, to
-/// avoid a race condition where the runtime starts shutting down while the
-/// task is still returning its result.
-///
-/// Returns `true` if this was the last context, `false` otherwise.
-pub fn exit_context() -> bool {
+/// Decrement context count on `__aexit__`.
+/// Returns `true` if this was the last context (count dropped to 0).
+pub(crate) fn exit_context() -> bool {
     let prev = ACTIVE_CONTEXTS.fetch_sub(1, Ordering::SeqCst);
     prev == 1
 }
 
-/// Get the current count of active client contexts.
-///
-/// Useful for debugging and testing automatic cleanup behavior.
-/// Returns 0 when no clients are in an active context manager.
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Get current active context count (for debugging/testing).
 #[pyfunction]
 pub fn active_context_count() -> usize {
     ACTIVE_CONTEXTS.load(Ordering::SeqCst)
 }
 
-/// Explicitly request graceful shutdown of the tokio runtime.
+/// Explicitly request graceful runtime shutdown.
 ///
-/// In most cases, the runtime is automatically cleaned up when the last
-/// client context exits. This function is provided for cases where explicit
-/// control is needed.
-///
-/// # Example
-///
-/// ```python
-/// import asyncio
-/// from etcd_client import cleanup_runtime
-///
-/// async def main():
-///     # Your etcd operations here
-///     ...
-///     # Explicit cleanup (usually not needed)
-///     cleanup_runtime()
-///
-/// asyncio.run(main())
-/// ```
-///
-/// This function uses tokio's `shutdown_timeout()` to gracefully shut down all tasks,
-/// waiting up to 5 seconds for pending tasks to complete.
+/// Usually not needed - runtime is automatically cleaned up when the last
+/// client context exits.
 #[pyfunction]
 pub fn cleanup_runtime() {
-    pyo3_async_runtimes::tokio::request_shutdown(5000);
+    pyo3_async_runtimes::tokio::request_shutdown(SHUTDOWN_TIMEOUT_MS);
 }
 
-/// Internal function to trigger runtime shutdown in the background.
-///
-/// This is called from Python AFTER the tokio task has completed and
-/// returned its result. This avoids a race condition where the runtime
-/// starts shutting down while a task is still trying to return.
-///
-/// Users should not call this directly - it's used internally by the
-/// client's `__aexit__` implementation.
+// ============================================================================
+// Internal Shutdown Helpers (used by __aexit__)
+// ============================================================================
+
+/// Trigger runtime shutdown in background. Called from Python after tokio task completes.
 #[pyfunction]
 pub fn _trigger_shutdown() {
-    pyo3_async_runtimes::tokio::request_shutdown_background(5000);
+    pyo3_async_runtimes::tokio::request_shutdown_background(SHUTDOWN_TIMEOUT_MS);
 }
 
-/// Internal function to join the pending runtime shutdown thread.
-///
-/// This is called from Python via `asyncio.to_thread()` to block until
-/// the runtime thread has fully terminated. The GIL is released during
-/// the blocking wait.
-///
-/// Users should not call this directly - it's used internally by the
-/// client's `__aexit__` implementation.
+/// Block until runtime thread terminates. Called via `asyncio.to_thread()`.
 #[pyfunction]
 pub fn _join_pending_shutdown(py: Python<'_>) -> bool {
     pyo3_async_runtimes::tokio::join_pending_shutdown(py)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,8 +1,52 @@
 use pyo3::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Request graceful shutdown of the tokio runtime.
+/// Count of active client context managers (those currently inside `async with`).
+static ACTIVE_CONTEXTS: AtomicUsize = AtomicUsize::new(0);
+
+/// Called when a client enters its async context (`__aenter__`).
 ///
-/// This should be called at the end of your main async function, before the event loop shuts down:
+/// Increments the active context count. If this is the first context after
+/// a previous shutdown, the tokio runtime will be lazily re-initialized
+/// on the first spawn operation.
+pub fn enter_context() {
+    ACTIVE_CONTEXTS.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Called when a client exits its async context (`__aexit__`).
+///
+/// Decrements the active context count. If this was the last active context
+/// (count drops from 1 to 0), automatically triggers runtime shutdown.
+///
+/// Returns `true` if cleanup was triggered, `false` otherwise.
+pub fn exit_context() -> bool {
+    let prev = ACTIVE_CONTEXTS.fetch_sub(1, Ordering::SeqCst);
+
+    if prev == 1 {
+        // Was 1, now 0 - last context exited, cleanup runtime
+        pyo3_async_runtimes::tokio::request_shutdown(5000);
+        true
+    } else {
+        false
+    }
+}
+
+/// Get the current count of active client contexts.
+///
+/// Useful for debugging and testing automatic cleanup behavior.
+/// Returns 0 when no clients are in an active context manager.
+#[pyfunction]
+pub fn active_context_count() -> usize {
+    ACTIVE_CONTEXTS.load(Ordering::SeqCst)
+}
+
+/// Explicitly request graceful shutdown of the tokio runtime.
+///
+/// In most cases, the runtime is automatically cleaned up when the last
+/// client context exits. This function is provided for cases where explicit
+/// control is needed.
+///
+/// # Example
 ///
 /// ```python
 /// import asyncio
@@ -11,7 +55,7 @@ use pyo3::prelude::*;
 /// async def main():
 ///     # Your etcd operations here
 ///     ...
-///     # Cleanup before returning
+///     # Explicit cleanup (usually not needed)
 ///     cleanup_runtime()
 ///
 /// asyncio.run(main())

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -73,3 +73,16 @@ pub fn active_context_count() -> usize {
 pub fn cleanup_runtime() {
     pyo3_async_runtimes::tokio::request_shutdown(5000);
 }
+
+/// Internal function to join the pending runtime shutdown thread.
+///
+/// This is called from Python via `asyncio.to_thread()` to block until
+/// the runtime thread has fully terminated. The GIL is released during
+/// the blocking wait.
+///
+/// Users should not call this directly - it's used internally by the
+/// client's `__aexit__` implementation.
+#[pyfunction]
+pub fn _join_pending_shutdown(py: Python<'_>) -> bool {
+    pyo3_async_runtimes::tokio::join_pending_shutdown(py)
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 
 from .harness import AsyncEtcd, ConfigScopes, HostPortPair
 
@@ -24,11 +24,12 @@ _etcd_command = """/usr/local/bin/etcd
 
 @pytest.fixture(scope="session")
 def etcd_container():
-    with DockerContainer(
-        f"gcr.io/etcd-development/etcd:{ETCD_VER}",
-        command=_etcd_command,
-    ).with_exposed_ports(2379) as container:
-        wait_for_logs(container, "ready to serve client requests")
+    container = (
+        DockerContainer(f"gcr.io/etcd-development/etcd:{ETCD_VER}", command=_etcd_command)
+        .with_exposed_ports(2379)
+        .waiting_for(LogMessageWaitStrategy("ready to serve client requests"))
+    )
+    with container:
         yield container
 
 

--- a/tests/test_auto_cleanup.py
+++ b/tests/test_auto_cleanup.py
@@ -1,0 +1,244 @@
+"""
+Tests for automatic tokio runtime cleanup via reference counting.
+
+These tests validate that:
+1. The runtime is automatically cleaned up when the last client context exits
+2. The runtime can be re-initialized for sequential client usage
+3. Multiple concurrent clients are handled correctly
+4. Exception scenarios maintain correct reference counts
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from etcd_client import Client, active_context_count
+
+
+@pytest.mark.asyncio
+async def test_single_client_context_count(etcd_container) -> None:
+    """Verify context count increments/decrements correctly for single client."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    client = Client([f"http://127.0.0.1:{etcd_port}"])
+
+    assert active_context_count() == 0
+
+    async with client.connect() as comm:
+        assert active_context_count() == 1
+        await comm.put(b"test_key", b"test_value")
+
+    # After context exit, count should be 0
+    assert active_context_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_concurrent_clients(etcd_container) -> None:
+    """Cleanup only happens when ALL clients exit."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    client1 = Client([f"http://127.0.0.1:{etcd_port}"])
+    client2 = Client([f"http://127.0.0.1:{etcd_port}"])
+
+    assert active_context_count() == 0
+
+    async with client1.connect() as c1:
+        assert active_context_count() == 1
+
+        async with client2.connect() as c2:
+            assert active_context_count() == 2
+            await c1.put(b"k1", b"v1")
+            await c2.put(b"k2", b"v2")
+
+        # client2 exited, but client1 still active
+        assert active_context_count() == 1
+        # Should still be able to use client1
+        value = await c1.get(b"k1")
+        assert bytes(value) == b"v1"
+
+    # Both exited
+    assert active_context_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_nested_contexts_same_client(etcd_container) -> None:
+    """Each context entry/exit is counted separately, even for same client."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    client = Client([f"http://127.0.0.1:{etcd_port}"])
+
+    assert active_context_count() == 0
+
+    async with client.connect():
+        assert active_context_count() == 1
+
+        # Same client, new connection
+        async with client.connect() as comm:
+            assert active_context_count() == 2
+            await comm.put(b"nested_key", b"nested_value")
+
+        assert active_context_count() == 1
+
+    assert active_context_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_exception_during_context(etcd_container) -> None:
+    """Count is decremented even if exception occurs during context."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    client = Client([f"http://127.0.0.1:{etcd_port}"])
+
+    assert active_context_count() == 0
+
+    with pytest.raises(ValueError, match="test error"):
+        async with client.connect() as comm:
+            assert active_context_count() == 1
+            await comm.put(b"exc_key", b"exc_value")
+            raise ValueError("test error")
+
+    # __aexit__ should still have been called
+    assert active_context_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_context_count_after_operation_failure(etcd_container) -> None:
+    """Count is properly managed even when operations fail inside context."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    client = Client([f"http://127.0.0.1:{etcd_port}"])
+
+    assert active_context_count() == 0
+
+    # Even if an operation fails, __aexit__ should properly decrement the count
+    async with client.connect() as comm:
+        assert active_context_count() == 1
+        await comm.put(b"fail_test_key", b"value")
+
+    # Count should be back to 0 after successful context exit
+    assert active_context_count() == 0
+
+
+def _make_sequential_test_script(etcd_port: int) -> str:
+    """Create a test script for sequential client usage with auto re-initialization."""
+    return f"""
+import asyncio
+from etcd_client import Client, active_context_count
+
+async def main():
+    client = Client(["http://127.0.0.1:{etcd_port}"])
+
+    # First session
+    async with client.connect() as comm:
+        await comm.put(b"seq_key", b"value1")
+        print(f"First session active: {{active_context_count()}}")
+
+    print(f"After first session: {{active_context_count()}}")
+    # Runtime was cleaned up here, should be re-initialized for second session
+
+    # Second session - runtime should reinitialize automatically
+    async with client.connect() as comm:
+        value = await comm.get(b"seq_key")
+        print(f"Second session active: {{active_context_count()}}")
+        assert bytes(value) == b"value1", f"Expected 'value1', got {{bytes(value)}}"
+
+    print(f"After second session: {{active_context_count()}}")
+    print("SUCCESS")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+"""
+
+
+@pytest.mark.asyncio
+async def test_sequential_clients_reinit(etcd_container) -> None:
+    """Runtime re-initializes for sequential client usage (subprocess test)."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    script = _make_sequential_test_script(etcd_port)
+
+    project_root = str(Path(__file__).parent.parent.resolve())
+    env = os.environ.copy()
+    env["PYTHONPATH"] = project_root
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(script)
+        script_path = f.name
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-u", script_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(
+                f"Sequential client test failed:\n"
+                f"stdout: {result.stdout}\n"
+                f"stderr: {result.stderr}"
+            )
+
+        assert "SUCCESS" in result.stdout, f"Test did not complete: {result.stdout}"
+    finally:
+        os.unlink(script_path)
+
+
+def _make_no_explicit_cleanup_script(etcd_port: int) -> str:
+    """Create a test script that does NOT call cleanup_runtime() explicitly."""
+    return f"""
+import asyncio
+from etcd_client import Client, active_context_count
+
+async def main():
+    client = Client(["http://127.0.0.1:{etcd_port}"])
+
+    async with client.connect() as comm:
+        await comm.put(b"auto_key", b"auto_value")
+        value = await comm.get(b"auto_key")
+        assert bytes(value) == b"auto_value"
+
+    # No cleanup_runtime() call - should be automatic
+    assert active_context_count() == 0
+    print("SUCCESS")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+"""
+
+
+@pytest.mark.asyncio
+async def test_no_explicit_cleanup_needed(etcd_container) -> None:
+    """Verify that explicit cleanup_runtime() is not needed (subprocess test)."""
+    etcd_port = etcd_container.get_exposed_port(2379)
+    script = _make_no_explicit_cleanup_script(etcd_port)
+
+    project_root = str(Path(__file__).parent.parent.resolve())
+    env = os.environ.copy()
+    env["PYTHONPATH"] = project_root
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(script)
+        script_path = f.name
+
+    try:
+        # Run multiple times to check for any shutdown issues
+        for i in range(5):
+            result = subprocess.run(
+                [sys.executable, "-u", script_path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Iteration {i+1} failed:\n"
+                    f"stdout: {result.stdout}\n"
+                    f"stderr: {result.stderr}"
+                )
+
+            assert "SUCCESS" in result.stdout
+    finally:
+        os.unlink(script_path)

--- a/tests/test_shutdown_stress.py
+++ b/tests/test_shutdown_stress.py
@@ -51,8 +51,16 @@ if __name__ == "__main__":
 """
 
 
-def _run_subprocess_test(script_content: str, iterations: int = 10) -> None:
-    """Run a test script in subprocess multiple times to detect shutdown issues."""
+def _run_subprocess_test(
+    script_content: str, iterations: int = 10, timeout: int = 10
+) -> None:
+    """Run a test script in subprocess multiple times to detect shutdown issues.
+
+    Args:
+        script_content: The Python script to run.
+        iterations: Number of times to run the script.
+        timeout: Subprocess timeout in seconds per iteration (default 10).
+    """
     project_root = str(Path(__file__).parent.parent.resolve())
     env = os.environ.copy()
     env["PYTHONPATH"] = project_root
@@ -68,7 +76,7 @@ def _run_subprocess_test(script_content: str, iterations: int = 10) -> None:
                 [sys.executable, "-u", script_path],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=timeout,
                 env=env,
             )
 
@@ -253,7 +261,8 @@ if __name__ == "__main__":
     main()
 """
 
-    _run_subprocess_test(script, iterations=10)
+    # Use longer timeout (20s) for multi-threaded test due to thread setup overhead
+    _run_subprocess_test(script, iterations=10, timeout=20)
 
 
 @pytest.mark.asyncio
@@ -316,4 +325,6 @@ if __name__ == "__main__":
     main()
 """
 
-    _run_subprocess_test(script, iterations=10)
+    # Use longer timeout (30s) for mixed concurrency test - most complex scenario
+    # with multiple threads each running multiple async tasks
+    _run_subprocess_test(script, iterations=10, timeout=30)

--- a/uv.lock
+++ b/uv.lock
@@ -151,12 +151,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "maturin", specifier = ">=1.10.2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
-    { name = "pytest", specifier = ">=8.4.1,<9" },
-    { name = "pytest-asyncio", specifier = ">=1.1.0,<2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.5" },
-    { name = "testcontainers", specifier = ">=4.12.0,<5" },
+    { name = "maturin", specifier = ">=1.11.2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
+    { name = "pytest", specifier = ">=9.0.2,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.10" },
+    { name = "testcontainers", specifier = ">=4.13.3,<5" },
     { name = "trafaret", specifier = ">=2.1,<3" },
 ]
 provides-extras = ["dev"]
@@ -266,26 +266,26 @@ wheels = [
 
 [[package]]
 name = "maturin"
-version = "1.10.2"
+version = "1.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/44/c593afce7d418ae6016b955c978055232359ad28c707a9ac6643fc60512d/maturin-1.10.2.tar.gz", hash = "sha256:259292563da89850bf8f7d37aa4ddba22905214c1e180b1c8f55505dfd8c0e81", size = 217835, upload-time = "2025-11-19T11:53:17.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/1c/00b48c6b93a5b3795ec96165a60dbafd3c5094aae281ba56812a8cad4fc7/maturin-1.11.2.tar.gz", hash = "sha256:24d2502ee8e6e6a33b3993bc78251da8d982e4da16d6c0ad9b4256135ff8694b", size = 226596, upload-time = "2026-01-05T21:11:45.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/74/7f7e93019bb71aa072a7cdf951cbe4c9a8d5870dd86c66ec67002153487f/maturin-1.10.2-py3-none-linux_armv6l.whl", hash = "sha256:11c73815f21a755d2129c410e6cb19dbfacbc0155bfc46c706b69930c2eb794b", size = 8763201, upload-time = "2025-11-19T11:52:42.98Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/85/1d1b64dbb6518ee633bfde8787e251ae59428818fea7a6bdacb8008a09bd/maturin-1.10.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7fbd997c5347649ee7987bd05a92bd5b8b07efa4ac3f8bcbf6196e07eb573d89", size = 17072583, upload-time = "2025-11-19T11:52:45.636Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/45/2418f0d6e1cbdf890205d1dc73ebea6778bb9ce80f92e866576c701ded72/maturin-1.10.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3ce9b2ad4fb9c341f450a6d32dc3edb409a2d582a81bc46ba55f6e3b6196b22", size = 8827021, upload-time = "2025-11-19T11:52:48.143Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/83/14c96ddc93b38745d8c3b85126f7d78a94f809a49dc9644bb22b0dc7b78c/maturin-1.10.2-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:f0d1b7b5f73c8d30a7e71cd2a2189a7f0126a3a3cd8b3d6843e7e1d4db50f759", size = 8751780, upload-time = "2025-11-19T11:52:51.613Z" },
-    { url = "https://files.pythonhosted.org/packages/46/8d/753148c0d0472acd31a297f6d11c3263cd2668d38278ed29d523625f7290/maturin-1.10.2-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:efcd496a3202ffe0d0489df1f83d08b91399782fb2dd545d5a1e7bf6fd81af39", size = 9241884, upload-time = "2025-11-19T11:52:53.946Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f9/f5ca9fe8cad70cac6f3b6008598cc708f8a74dd619baced99784a6253f23/maturin-1.10.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a41ec70d99e27c05377be90f8e3c3def2a7bae4d0d9d5ea874aaf2d1da625d5c", size = 8671736, upload-time = "2025-11-19T11:52:57.133Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/76/f59cbcfcabef0259c3971f8b5754c85276a272028d8363386b03ec4e9947/maturin-1.10.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:07a82864352feeaf2167247c8206937ef6c6ae9533025d416b7004ade0ea601d", size = 8633475, upload-time = "2025-11-19T11:53:00.389Z" },
-    { url = "https://files.pythonhosted.org/packages/53/40/96cd959ad1dda6c12301860a74afece200a3209d84b393beedd5d7d915c0/maturin-1.10.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:04df81ee295dcda37828bd025a4ac688ea856e3946e4cb300a8f44a448de0069", size = 11177118, upload-time = "2025-11-19T11:53:03.014Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/b6/144f180f36314be183f5237011528f0e39fe5fd2e74e65c3b44a5795971e/maturin-1.10.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96e1d391e4c1fa87edf2a37e4d53d5f2e5f39dd880b9d8306ac9f8eb212d23f8", size = 9320218, upload-time = "2025-11-19T11:53:05.39Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/2d/2c483c1b3118e2e10fd8219d5291843f5f7c12284113251bf506144a3ac1/maturin-1.10.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a217aa7c42aa332fb8e8377eb07314e1f02cf0fe036f614aca4575121952addd", size = 8985266, upload-time = "2025-11-19T11:53:07.618Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/98/1d0222521e112cd058b56e8d96c72cf9615f799e3b557adb4b16004f42aa/maturin-1.10.2-py3-none-win32.whl", hash = "sha256:da031771d9fb6ddb1d373638ec2556feee29e4507365cd5749a2d354bcadd818", size = 7667897, upload-time = "2025-11-19T11:53:10.14Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/ec/c6c973b1def0d04533620b439d5d7aebb257657ba66710885394514c8045/maturin-1.10.2-py3-none-win_amd64.whl", hash = "sha256:da777766fd584440dc9fecd30059a94f85e4983f58b09e438ae38ee4b494024c", size = 8908416, upload-time = "2025-11-19T11:53:12.862Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/01/7da60c9f7d5dc92dfa5e8888239fd0fb2613ee19e44e6db5c2ed5595fab3/maturin-1.10.2-py3-none-win_arm64.whl", hash = "sha256:a4c29a770ea2c76082e0afc6d4efd8ee94405588bfae00d10828f72e206c739b", size = 7506680, upload-time = "2025-11-19T11:53:15.403Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c4/85478aeffd361c14b283464a8f240fa6f8f93a5413458d1aeedffdd39a9b/maturin-1.11.2-py3-none-linux_armv6l.whl", hash = "sha256:92cad385d383d9effef2b532085098c6d555f9993566cdead14e0a70fb900aa6", size = 8852599, upload-time = "2026-01-05T21:11:44.465Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e8/0f9542984b740120c07ef6b1f1eff7ce4ee45e32c2ad69db87b9729b4007/maturin-1.11.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7dff6b23d7ae70608d0ad7651e3d5acb8f8c982d2a3bccd8b3fbbc2b3696d84b", size = 17237591, upload-time = "2026-01-05T21:11:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5c/2271c7f952dc4ac8bbf86d2f45f2d005d843d2f67d1f0c3675027adc5967/maturin-1.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:170ade0cb2816f1e0d050c7eb94906b90d59906d31428286ad5683ee3379c403", size = 8885232, upload-time = "2026-01-05T21:11:30.994Z" },
+    { url = "https://files.pythonhosted.org/packages/26/eb/ae3bd7ef6f74d19b8fc00dcdf301abd0344d9840096b8094b2a8c68186d7/maturin-1.11.2-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:38b593e9dc55ddc68baac5b356be7ceeabf5bde89ae1f77269b817cfb4ad2f7c", size = 8870567, upload-time = "2026-01-05T21:11:36.773Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/d0397393b1096e01bc553ff253d4f5847ec75b48313ed2239a0677cc6f27/maturin-1.11.2-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:e4adfd055220a1d4d9d13fc63ef78750ee3769e913d9453fe18cd2ce14bb72fb", size = 9294907, upload-time = "2026-01-05T21:11:50.475Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f7/f2aac58e4a09ce0ea6cbfae3831a7eaf04bd830464f677fba5519fa277d1/maturin-1.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:3a381b231b453e5cf2ca9cd1666061e4f712ac34bd2e339bc90e692f7d9f6a20", size = 8834287, upload-time = "2026-01-05T21:11:46.794Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5a/029db0c105debfe334c3b76d7d7575ea658841726372ea531c4eb77d21cc/maturin-1.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:60fa20b43bdd0438fac9dea9221f19a278a4a6d9b52c67d53184fa905959cf54", size = 8728055, upload-time = "2026-01-05T21:11:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f0/d48c944151c9373901705f3f11c004233c1a72199408e8585ad66bc3b063/maturin-1.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:4dd8c0b0c0f4b5d584bcdba62b0af339366933fabe56cfa187f193f1860c84f3", size = 11385341, upload-time = "2026-01-05T21:11:35.058Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d7/7548a8d561a215531e2859e77a421b7fc6d542c6dc8087175eba54f24367/maturin-1.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fde6d45b6efec43e6bf06b143ec06808599784be3f44f5e2914e33b8d3639d66", size = 9429750, upload-time = "2026-01-05T21:11:38.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/bf/d581d8a938fc1f0e414f5454e745524a9cea7786990fa7a1222d2563f32b/maturin-1.11.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:97c454f764232c0488dddcabd61120bbd413811e8f8ef4952ca46e5aade71134", size = 9099156, upload-time = "2026-01-05T21:11:48.407Z" },
+    { url = "https://files.pythonhosted.org/packages/43/43/8f29d880034256144b8f72706c95e2d8c5d8b1045cd4a1783e52f1e02dd2/maturin-1.11.2-py3-none-win32.whl", hash = "sha256:bfcaaef0f72a0153a8965f45a9f1b3682658386fdd53a5ca4709ffb9a4f9a652", size = 7753292, upload-time = "2026-01-05T21:11:54.797Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/96/8931519e4aca020d2d8fb39e47b5be1a2446073ea3708f3efb046c9790c3/maturin-1.11.2-py3-none-win_amd64.whl", hash = "sha256:715d8fb30593f7aa2f02d7287f34568698596a64c08ba65e8dcd35475fb5456b", size = 9030254, upload-time = "2026-01-05T21:11:40.951Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/baf33fcc61d4146a9a9ae7eedb414a90aa0923534112d700487f11d6e70a/maturin-1.11.2-py3-none-win_arm64.whl", hash = "sha256:0a25365428cdb9170c515a4b81f1dad220bd3c8ee333f612f557f91ff60c2b06", size = 7633080, upload-time = "2026-01-05T21:11:42.719Z" },
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -392,9 +392,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements automatic tokio runtime cleanup when the last client context exits
- Uses reference counting to track active client contexts
- Shutdown completes within the async context to avoid deadlocks
- Users no longer need to call `cleanup_runtime()` explicitly

## Changes

### pyo3-async-runtimes (vendored)

- Changed `RUNTIME_WRAPPER` from `OnceLock` to `RwLock<Option<...>>` for re-initialization support
- Added `request_shutdown_background()` - signals shutdown without blocking
- Added `join_pending_shutdown()` - blocks until runtime thread terminates (GIL released)
- Removed atexit handler approach (caused issues with multi-threaded scenarios)

### etcd-client-py

**Runtime management (`src/runtime.rs`):**
- Added `SHUTDOWN_TIMEOUT_MS` constant (5000ms)
- Added `ACTIVE_CONTEXTS` atomic counter for reference counting
- `enter_context()` / `exit_context()` - internal functions to track contexts
- `active_context_count()` - public function for debugging/testing
- `_trigger_shutdown()` / `_join_pending_shutdown()` - internal helpers for `__aexit__`

**Client (`src/client.rs`):**
- `__aenter__` increments context count before async work
- `__aexit__` uses a 3-phase shutdown sequence:
  1. Await tokio cleanup task (returns `is_last_context` flag)
  2. If last context: call `_trigger_shutdown()` from Python (after tokio task completes)
  3. Await `asyncio.to_thread(_join_pending_shutdown)` to block until runtime terminates
- This ensures shutdown happens within the async context, avoiding deadlocks

**Tests:**
- Added `test_shutdown_stress.py` with comprehensive stress tests:
  - `test_shutdown_multi_async_tasks` - multiple async tasks sharing one event loop
  - `test_shutdown_multi_threaded` - multiple threads with separate event loops
  - `test_shutdown_mixed_concurrency` - threads × async tasks (most complex)
- Added timeout constants for CI stability

**Documentation:**
- Updated README with reorganized structure
- Added "Automatic runtime cleanup" section explaining the mechanism

## Key Design Decision

The shutdown trigger is called from Python **after** the tokio task completes, not from within the task. This avoids a race condition where the runtime could start shutting down while a task is still returning its result to Python.

## Test Plan

- [x] `test_single_client_context_count` - single client lifecycle
- [x] `test_multiple_concurrent_clients` - cleanup only when all clients exit
- [x] `test_nested_contexts_same_client` - nested contexts counted separately
- [x] `test_exception_during_context` - count decremented on exception
- [x] `test_sequential_clients_reinit` - runtime re-initialization works
- [x] `test_no_explicit_cleanup_needed` - no segfaults without explicit cleanup
- [x] `test_shutdown_multi_async_tasks` - 5 concurrent tasks, 20 iterations
- [x] `test_shutdown_multi_threaded` - 4 threads, 10 iterations
- [x] `test_shutdown_mixed_concurrency` - 3 threads × 3 tasks, 10 iterations
- [x] All 24 tests pass on Python 3.11-3.14 (including 3.14t free-threaded)
- [x] All tests pass on both x86_64 and aarch64

## Related

- Builds on #14 - eliminates the need for manual `cleanup_runtime()` calls
- Fixes deadlock issues in Python 3.11/3.12 during shutdown
- Reference: [BA-1976](https://lablup.atlassian.net/browse/BA-1976), [pyo3-async-runtimes#40](https://github.com/PyO3/pyo3-async-runtimes/issues/40)

[BA-1976]: https://lablup.atlassian.net/browse/BA-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ